### PR TITLE
docs(OpenAPI): enhance OpenAPI descriptions for endpoints, request an…

### DIFF
--- a/src/main/kotlin/com/catenax/gpdm/component/cdq/controller/CdqController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/component/cdq/controller/CdqController.kt
@@ -4,6 +4,10 @@ import com.catenax.gpdm.component.cdq.service.PartnerExportPageService
 import com.catenax.gpdm.component.cdq.service.PartnerImportService
 import com.catenax.gpdm.component.cdq.dto.BusinessPartnerCdq
 import com.catenax.gpdm.dto.response.BusinessPartnerResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -14,12 +18,27 @@ class CdqController(
     val partnerImportService: PartnerImportService,
     val partnerExportPageService: PartnerExportPageService
 ) {
-
+    @Operation(summary = "Import new business partner records from CDQ",
+        description = "Triggers an import of new business partner records from CDQ. " +
+                "A CDQ record counts as new when it does not have a BPN and the BPDM service does not already have a record with the same CDQ ID. " +
+                "This import only regards records with a modifiedAfter timestamp since the last import.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Import performed successfully"),
+        ApiResponse(responseCode = "500", description = "Import failed (no connection to CDQ or database)", content = [Content()])
+    ])
     @PostMapping("/business-partners/import")
     fun importBusinessPartners(): Collection<BusinessPartnerResponse> {
         return partnerImportService.import()
     }
 
+    @Operation(summary = "Export of BPNs to CDQ records",
+        description = "Triggers an export of BPNs from BPDM to CDQ. " +
+                "Regards business partner records in the BPDM system without a synchronized CDQ identifier status. " +
+                "Only exports BPNs and keeps other properties of the CDQ record untouched.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Export of BPNs performed successfully"),
+        ApiResponse(responseCode = "500", description = "Export failed (no connection to CDQ or database)", content = [Content()])
+    ])
     @PostMapping("/business-partners/export")
     fun getBusinessPartners(): Collection<BusinessPartnerCdq> {
         return partnerExportPageService.export()

--- a/src/main/kotlin/com/catenax/gpdm/component/elastic/impl/controller/ElasticSearchController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/component/elastic/impl/controller/ElasticSearchController.kt
@@ -2,6 +2,10 @@ package com.catenax.gpdm.component.elastic.impl.controller
 
 import com.catenax.gpdm.dto.elastic.BusinessPartnerDoc
 import com.catenax.gpdm.component.elastic.impl.service.ElasticSyncService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -18,11 +22,25 @@ class ElasticSearchController(
     val elasticSyncService: ElasticSyncService
 ) {
 
+    @Operation(summary = "Index new business partner records on Elasticsearch",
+        description = "Triggers an export of business partner records from BPDM to Elasticsearch. " +
+                "Only exports records which have been updated since the last export. ")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Export of records successfully"),
+        ApiResponse(responseCode = "500", description = "Export failed (no connection to Elasticsearch or database)", content = [Content()])
+    ])
     @PostMapping("/business-partners")
     fun export(): Collection<BusinessPartnerDoc> {
         return elasticSyncService.exportPartnersToElastic()
     }
 
+    @Operation(summary = "Clear business partner index on Elasticsearch",
+        description = "Deletes all business partner records in the Elasticsearch index. " +
+                "Also resets the timestamp from the last export.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Index successfully cleared"),
+        ApiResponse(responseCode = "500", description = "Clearing failed (no connection to Elasticsearch or database)", content = [Content()])
+    ])
     @DeleteMapping("/business-partners")
     fun clear(){
         return elasticSyncService.clearElastic()

--- a/src/main/kotlin/com/catenax/gpdm/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/catenax/gpdm/config/OpenApiConfig.kt
@@ -1,15 +1,32 @@
 package com.catenax.gpdm.config
 
+import com.catenax.gpdm.dto.response.PageResponse
+import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
+import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
+import com.catenax.gpdm.dto.response.type.TypeNameUrlDto
+import com.catenax.gpdm.entity.CharacterSet
+import io.swagger.v3.core.converter.AnnotatedType
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.OAuthFlow
 import io.swagger.v3.oas.models.security.OAuthFlows
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import org.springdoc.core.OpenAPIService
+import org.springdoc.core.SpringDocUtils
+import org.springdoc.core.customizers.OpenApiBuilderCustomizer
+import org.springdoc.core.customizers.OpenApiCustomiser
+import org.springdoc.core.customizers.PropertyCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
+
 
 @Configuration
 class OpenApiConfig(
@@ -39,3 +56,12 @@ class OpenApiConfig(
     }
 
 }
+
+@Component
+class SortSchemasCustomiser : OpenApiCustomiser {
+    override fun customise(openApi: OpenAPI) {
+        val sortedSchemas = openApi.components.schemas.values.sortedBy { it.name }
+        openApi.components.schemas = sortedSchemas.associateBy { it.name }
+    }
+}
+

--- a/src/main/kotlin/com/catenax/gpdm/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/catenax/gpdm/config/OpenApiConfig.kt
@@ -1,31 +1,17 @@
 package com.catenax.gpdm.config
 
-import com.catenax.gpdm.dto.response.PageResponse
-import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
-import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
-import com.catenax.gpdm.dto.response.type.TypeNameUrlDto
-import com.catenax.gpdm.entity.CharacterSet
-import io.swagger.v3.core.converter.AnnotatedType
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.media.ArraySchema
-import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.OAuthFlow
 import io.swagger.v3.oas.models.security.OAuthFlows
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
-import org.springdoc.core.OpenAPIService
-import org.springdoc.core.SpringDocUtils
-import org.springdoc.core.customizers.OpenApiBuilderCustomizer
 import org.springdoc.core.customizers.OpenApiCustomiser
-import org.springdoc.core.customizers.PropertyCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
-import kotlin.reflect.KClass
-import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
 
 
 @Configuration

--- a/src/main/kotlin/com/catenax/gpdm/controller/BusinessPartnerController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/controller/BusinessPartnerController.kt
@@ -8,6 +8,13 @@ import com.catenax.gpdm.dto.request.PaginationRequest
 import com.catenax.gpdm.dto.response.BusinessPartnerResponse
 import com.catenax.gpdm.dto.response.PageResponse
 import com.catenax.gpdm.service.BusinessPartnerService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springdoc.api.annotations.ParameterObject
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
@@ -19,24 +26,61 @@ class BusinessPartnerController(
     val businessPartnerService: BusinessPartnerService,
     val bpnConfigProperties: BpnConfigProperties
 ) {
+
+    @Operation(summary = "Get page of business partners matching the search criteria",
+    description = "This endpoint tries to find matches among all existing business partners, " +
+            "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. " +
+            "The match of a partner is better the higher its relevancy score.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+        ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+    ])
     @GetMapping
-    fun getBusinessPartners(@ParameterObject searchRequest: BusinessPartnerSearchRequest,
-                            @ParameterObject paginationRequest: PaginationRequest
+    fun getBusinessPartners(
+        @ParameterObject
+        searchRequest: BusinessPartnerSearchRequest,
+        @ParameterObject
+        paginationRequest: PaginationRequest
     ): PageResponse<BusinessPartnerResponse> {
         return businessPartnerService.findPartners(searchRequest, PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 
+    @Operation(summary = "Get business partner by identifier",
+    description = "This endpoint tries to find a business partner by the specified identifier. " +
+            "The identifier value is case insensitively compared but needs to be given exactly. " +
+            "By default the value given is interpreted as a BPN. " +
+            "By specifying the technical key of another identifier type" +
+            "the value is matched against the identifiers of that given type.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Found business partner with specified identifier"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "404", description = "No business partner found under specified identifier or specified identifier type not found", content = [Content()])
+    ])
     @GetMapping("/{idValue}")
-    fun getBusinessPartner(@PathVariable idValue: String,
-                           @RequestParam idType: String?
+    fun getBusinessPartner(
+        @Parameter(description = "Identifier value")
+        @PathVariable
+        idValue: String,
+        @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
+        @RequestParam
+        idType: String?
     ): BusinessPartnerResponse {
         val actualType = idType ?: bpnConfigProperties.id
         return if(actualType == bpnConfigProperties.id) businessPartnerService.findPartner(idValue)
         else businessPartnerService.findPartnerByIdentifier(actualType, idValue)
     }
 
+    @Operation(summary = "Create new business partner record",
+    description = "Endpoint to create new business partner records directly in the system. Currently for test purposes only.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "New business partner record successfully created"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "404", description = "Metadata referenced by technical key not found", content = [Content()])
+    ])
     @PostMapping
-    fun createBusinessPartners(@RequestBody businessPartners: Collection<BusinessPartnerRequest>) : Collection<BusinessPartnerResponse>{
+    fun createBusinessPartners(
+        @RequestBody
+        businessPartners: Collection<BusinessPartnerRequest>) : Collection<BusinessPartnerResponse>{
         return businessPartnerService.createPartners(businessPartners)
     }
 

--- a/src/main/kotlin/com/catenax/gpdm/controller/BusinessPartnerController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/controller/BusinessPartnerController.kt
@@ -1,7 +1,6 @@
 package com.catenax.gpdm.controller
 
 import com.catenax.gpdm.config.BpnConfigProperties
-import com.catenax.gpdm.dto.request.AddressSearchRequest
 import com.catenax.gpdm.dto.request.BusinessPartnerRequest
 import com.catenax.gpdm.dto.request.BusinessPartnerSearchRequest
 import com.catenax.gpdm.dto.request.PaginationRequest
@@ -10,7 +9,6 @@ import com.catenax.gpdm.dto.response.PageResponse
 import com.catenax.gpdm.service.BusinessPartnerService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -18,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springdoc.api.annotations.ParameterObject
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
-import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/catena/business-partner")

--- a/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
@@ -8,54 +8,133 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.service.MetadataService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.Parameters
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springdoc.api.annotations.ParameterObject
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
+import javax.validation.constraints.PositiveOrZero
 
 @RestController
 @RequestMapping("/api/catena")
 class MetadataController (
        val metadataService: MetadataService
         ){
-        @PostMapping("/identifier-type")
-        fun createIdentifierType(@RequestBody type: TypeKeyNameUrlDto<String>): TypeKeyNameUrlDto<String> {
-                return metadataService.createIdentifierType(type)
-        }
 
-        @GetMapping("/identifier-type")
-        fun getIdentifierTypes(@Valid paginationRequest: PaginationRequest): PageResponse<TypeKeyNameUrlDto<String>> {
-                return metadataService.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size))
-        }
+    @Operation(summary = "Create new identifier type",
+    description = "Create a new identifier type which can be referenced by business partner records. " +
+            "Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. " +
+            "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
+            "A recommendation for technical keys: They should be short, descriptive and " +
+            "use a restricted common character set in order to ensure compatibility with older systems." +
+            "The actual name of the identifier type is free to choose and doesn't need to be unique.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "New identifier type successfully created"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "409", description = "Identifier type with specified technical key already exists", content = [Content()])
+    ])
+    @PostMapping("/identifier-type")
+    fun createIdentifierType(@RequestBody type: TypeKeyNameUrlDto<String>): TypeKeyNameUrlDto<String> {
+            return metadataService.createIdentifierType(type)
+    }
 
-        @PostMapping("/identifier-status")
-        fun createIdentifierStatus(@RequestBody status: TypeKeyNameDto<String>): TypeKeyNameDto<String> {
-            return metadataService.createIdentifierStatus(status)
-        }
-    
-        @GetMapping("/identifier-status")
-        fun getIdentifierStati(@Valid paginationRequest: PaginationRequest): PageResponse<TypeKeyNameDto<String>> {
-            return metadataService.getIdentifierStati(PageRequest.of(paginationRequest.page, paginationRequest.size))
-        }
+    @Operation(summary = "Get page of identifier types",
+        description = "Lists all currently known identifier types in a paginated result")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Page of existing identifier types, may be empty"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+    ])
+    @GetMapping("/identifier-type")
+    fun getIdentifierTypes(@ParameterObject paginationRequest: PaginationRequest): PageResponse<TypeKeyNameUrlDto<String>> {
+            return metadataService.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
 
-        @PostMapping("/issuing-body")
-        fun createIssuingBody(@RequestBody type: TypeKeyNameUrlDto<String>): TypeKeyNameUrlDto<String> {
-                return metadataService.createIssuingBody(type)
-        }
+    @Operation(summary = "Create new identifier status",
+        description = "Create a new identifier status which can be referenced by business partner records. " +
+                "A status further distinguishes an identifier by adding current status information such as active or revoked." +
+                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
+                "A recommendation for technical keys: They should be short, descriptive and " +
+                "use a restricted common character set in order to ensure compatibility with older systems." +
+                "The actual name of the identifier status is free to choose and doesn't need to be unique.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "New identifier status successfully created"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "409", description = "Identifier status with specified technical key already exists", content = [Content()])
+    ])
+    @PostMapping("/identifier-status")
+    fun createIdentifierStatus(@RequestBody status: TypeKeyNameDto<String>): TypeKeyNameDto<String> {
+        return metadataService.createIdentifierStatus(status)
+    }
 
-        @GetMapping("/issuing-body")
-        fun getIssuingBodies(@Valid paginationRequest: PaginationRequest): PageResponse<TypeKeyNameUrlDto<String>> {
-                return metadataService.getIssuingBodies(PageRequest.of(paginationRequest.page, paginationRequest.size))
-        }
+    @Operation(summary = "Get page of identifier statuses",
+        description = "Lists all currently known identifier statuses in a paginated result")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Page of existing identifier statuses, may be empty"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+    ])
+    @GetMapping("/identifier-status")
+    fun getIdentifierStati(@ParameterObject paginationRequest: PaginationRequest): PageResponse<TypeKeyNameDto<String>> {
+        return metadataService.getIdentifierStati(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
 
-        @PostMapping("/legal-form")
-        fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormResponse {
-                return metadataService.createLegalForm(type)
-        }
+    @Operation(summary = "Create new issuing body",
+        description = "Create a new issuing body which can be referenced by business partner records. " +
+                "An issuing body should be an entity which the Catena organisation trusts to issue identifiers." +
+                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
+                "A recommendation for technical keys: They should be short, descriptive and " +
+                "use a restricted common character set in order to ensure compatibility with older systems." +
+                "The actual name of the issuing body is free to choose and doesn't need to be unique.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "New issuing body successfully created"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "409", description = "Issuing body with specified technical key already exists", content = [Content()])
+    ])
+    @PostMapping("/issuing-body")
+    fun createIssuingBody(@RequestBody type: TypeKeyNameUrlDto<String>): TypeKeyNameUrlDto<String> {
+            return metadataService.createIssuingBody(type)
+    }
+
+    @Operation(summary = "Get page of issuing bodies",
+        description = "Lists all currently known issuing bodies in a paginated result")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Page of existing issuing bodies, may be empty"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+    ])
+    @GetMapping("/issuing-body")
+    fun getIssuingBodies(@ParameterObject paginationRequest: PaginationRequest): PageResponse<TypeKeyNameUrlDto<String>> {
+            return metadataService.getIssuingBodies(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
+
+    @Operation(summary = "Create new legal form",
+        description = "Create a new legal form which can be referenced by business partner records. " +
+                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
+                "A recommendation for technical keys: They should be short, descriptive and " +
+                "use a restricted common character set in order to ensure compatibility with older systems." +
+                "The actual name of the legal form is free to choose and doesn't need to be unique.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "New legal form successfully created"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+        ApiResponse(responseCode = "409", description = "Legal form with specified technical key already exists", content = [Content()])
+    ])
+    @PostMapping("/legal-form")
+    fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormResponse {
+            return metadataService.createLegalForm(type)
+    }
 
 
-        @GetMapping("/legal-form")
-        @Operation(method = "getLegalForms")
-        fun getLegalForms(@Valid paginationRequest: PaginationRequest): PageResponse<LegalFormResponse> {
-                return metadataService.getLegalForms(PageRequest.of(paginationRequest.page, paginationRequest.size))
-        }
+    @Operation(summary = "Get page of legal forms",
+        description = "Lists all currently known legal forms in a paginated result")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Page of existing legal forms, may be empty"),
+        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+    ])
+    @GetMapping("/legal-form")
+    fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageResponse<LegalFormResponse> {
+            return metadataService.getLegalForms(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
 }

--- a/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
@@ -21,18 +21,26 @@ class MetadataController (
        val metadataService: MetadataService
         ){
 
-    @Operation(summary = "Create new identifier type",
-    description = "Create a new identifier type which can be referenced by business partner records. " +
-            "Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. " +
+    companion object DescriptionObject {
+        const val technicalKeyDisclaimer =
             "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
-            "A recommendation for technical keys: They should be short, descriptive and " +
-            "use a restricted common character set in order to ensure compatibility with older systems." +
-            "The actual name of the identifier type is free to choose and doesn't need to be unique.")
-    @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "New identifier type successfully created"),
-        ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-        ApiResponse(responseCode = "409", description = "Identifier type with specified technical key already exists", content = [Content()])
-    ])
+                    "A recommendation for technical keys: They should be short, descriptive and " +
+                    "use a restricted common character set in order to ensure compatibility with older systems."
+    }
+
+    @Operation(
+        summary = "Create new identifier type",
+        description = "Create a new identifier type which can be referenced by business partner records. " +
+                "Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. " +
+                "The actual name of the identifier type is free to choose and doesn't need to be unique. $technicalKeyDisclaimer"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New identifier type successfully created"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(responseCode = "409", description = "Identifier type with specified technical key already exists", content = [Content()])
+        ]
+    )
     @PostMapping("/identifier-type")
     fun createIdentifierType(@RequestBody type: TypeKeyNameUrlDto<String>): TypeKeyNameUrlDto<String> {
             return metadataService.createIdentifierType(type)
@@ -49,13 +57,12 @@ class MetadataController (
             return metadataService.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 
-    @Operation(summary = "Create new identifier status",
+    @Operation(
+        summary = "Create new identifier status",
         description = "Create a new identifier status which can be referenced by business partner records. " +
                 "A status further distinguishes an identifier by adding current status information such as active or revoked." +
-                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
-                "A recommendation for technical keys: They should be short, descriptive and " +
-                "use a restricted common character set in order to ensure compatibility with older systems." +
-                "The actual name of the identifier status is free to choose and doesn't need to be unique.")
+                "The actual name of the identifier status is free to choose and doesn't need to be unique. $technicalKeyDisclaimer"
+    )
     @ApiResponses(value = [
         ApiResponse(responseCode = "200", description = "New identifier status successfully created"),
         ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
@@ -77,13 +84,12 @@ class MetadataController (
         return metadataService.getIdentifierStati(PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 
-    @Operation(summary = "Create new issuing body",
+    @Operation(
+        summary = "Create new issuing body",
         description = "Create a new issuing body which can be referenced by business partner records. " +
                 "An issuing body should be an entity which the Catena organisation trusts to issue identifiers." +
-                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
-                "A recommendation for technical keys: They should be short, descriptive and " +
-                "use a restricted common character set in order to ensure compatibility with older systems." +
-                "The actual name of the issuing body is free to choose and doesn't need to be unique.")
+                "The actual name of the issuing body is free to choose and doesn't need to be unique. $technicalKeyDisclaimer"
+    )
     @ApiResponses(value = [
         ApiResponse(responseCode = "200", description = "New issuing body successfully created"),
         ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
@@ -105,12 +111,11 @@ class MetadataController (
             return metadataService.getIssuingBodies(PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 
-    @Operation(summary = "Create new legal form",
+    @Operation(
+        summary = "Create new legal form",
         description = "Create a new legal form which can be referenced by business partner records. " +
-                "The technical key can be freely chosen but needs to be unique as it is used as reference by the business partner records. " +
-                "A recommendation for technical keys: They should be short, descriptive and " +
-                "use a restricted common character set in order to ensure compatibility with older systems." +
-                "The actual name of the legal form is free to choose and doesn't need to be unique.")
+                "The actual name of the legal form is free to choose and doesn't need to be unique. " + technicalKeyDisclaimer
+    )
     @ApiResponses(value = [
         ApiResponse(responseCode = "200", description = "New legal form successfully created"),
         ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),

--- a/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
+++ b/src/main/kotlin/com/catenax/gpdm/controller/MetadataController.kt
@@ -8,17 +8,12 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.service.MetadataService
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.Parameters
 import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springdoc.api.annotations.ParameterObject
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
-import javax.validation.Valid
-import javax.validation.constraints.PositiveOrZero
 
 @RestController
 @RequestMapping("/api/catena")

--- a/src/main/kotlin/com/catenax/gpdm/dto/GeoCoordinateDto.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/GeoCoordinateDto.kt
@@ -1,7 +1,13 @@
 package com.catenax.gpdm.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Geo Coordinates", description = "New geo coordinates record for an address")
 data class GeoCoordinateDto (
+    @Schema(description = "Longitude coordinate")
     val longitude: Float,
+    @Schema(description = "Latitude coordinate")
     val latitude: Float,
+    @Schema(description = "Altitude, if applicable")
     val altitude: Float?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/AddressRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/AddressRequest.kt
@@ -3,18 +3,33 @@ package com.catenax.gpdm.dto.request
 import com.catenax.gpdm.dto.GeoCoordinateDto
 import com.catenax.gpdm.entity.AddressType
 import com.neovisionaries.i18n.CountryCode
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Address Request", description = "New localized address record for a business partner")
 data class AddressRequest (
-    val version: AddressVersionRequest,
+    @Schema(description = "Language and character set the address is written in")
+    val version: AddressVersionRequest = AddressVersionRequest(),
+    @Schema(description = "Entity which is in care of this address")
     val careOf: String?,
+    @Schema(description = "Contexts of this address")
     val contexts: Collection<String> = emptyList(),
+    @Schema(description = "Address country", defaultValue = "UNDEFINED")
     val country: CountryCode = CountryCode.UNDEFINED,
+    @ArraySchema(arraySchema = Schema(description = "Area such as country region or county", defaultValue = "[]"))
     val administrativeAreas: Collection<AdministrativeAreaRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Postcodes assigned to this address", defaultValue = "[]"))
     val postCodes: Collection<PostCodeRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "City, block and/or quarter", defaultValue = "[]"))
     val localities: Collection<LocalityRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Street, zone and/or square", defaultValue = "[]"))
     val thoroughfares: Collection<ThoroughfareRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Building, level and/or room", defaultValue = "[]"))
     val premises: Collection<PremiseRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Postal delivery points", defaultValue = "[]"))
     val postalDeliveryPoints: Collection<PostalDeliveryPointRequest> = emptyList(),
+    @Schema(description = "Geographic coordinates to find this location")
     val geographicCoordinates: GeoCoordinateDto?,
+    @ArraySchema(arraySchema = Schema(description = "Type of address", defaultValue = "[]"))
     val types: Collection<AddressType> = emptyList()
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/AddressSearchRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/AddressSearchRequest.kt
@@ -1,24 +1,12 @@
 package com.catenax.gpdm.dto.request
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.boot.context.properties.ConstructorBinding
-import org.springframework.data.elasticsearch.annotations.Field
-import org.springframework.data.elasticsearch.annotations.FieldType
-import org.springframework.web.bind.annotation.RequestParam
 
-@Schema(name = "Address Search Request", description = "Search request for addresses with keywords for address properties")
 data class AddressSearchRequest @ConstructorBinding constructor(
-    @Schema(description = "Which area, region or county")
     var administrativeArea: String? = null,
-    @Schema(description = "Which postcode or postcodes")
     var postCode: String? = null,
-    @Schema(description = "Which city, block or quarter")
     var locality: String? = null,
-    @Schema(description = "Which street, zone or square")
     var thoroughfare: String? = null,
-    @Schema(description = "Which building, level or room")
     var premise: String? = null,
-    @Schema(description = "Which postal delivery point")
     var postalDeliveryPoint: String? = null
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/AddressSearchRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/AddressSearchRequest.kt
@@ -1,16 +1,24 @@
 package com.catenax.gpdm.dto.request
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.web.bind.annotation.RequestParam
 
+@Schema(name = "Address Search Request", description = "Search request for addresses with keywords for address properties")
 data class AddressSearchRequest @ConstructorBinding constructor(
+    @Schema(description = "Which area, region or county")
     var administrativeArea: String? = null,
+    @Schema(description = "Which postcode or postcodes")
     var postCode: String? = null,
+    @Schema(description = "Which city, block or quarter")
     var locality: String? = null,
+    @Schema(description = "Which street, zone or square")
     var thoroughfare: String? = null,
+    @Schema(description = "Which building, level or room")
     var premise: String? = null,
+    @Schema(description = "Which postal delivery point")
     var postalDeliveryPoint: String? = null
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/AddressVersionRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/AddressVersionRequest.kt
@@ -2,8 +2,12 @@ package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.CharacterSet
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Address Version Request", description = "New localization record for an address")
 data class AddressVersionRequest (
+    @Schema(description = "Character set in which the address is written", defaultValue = "UNDEFINED")
     val characterSet: CharacterSet = CharacterSet.UNDEFINED,
+    @Schema(description = "Language in which the address is written", defaultValue = "undefined")
     val language: LanguageCode = LanguageCode.undefined
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/AdministrativeAreaRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/AdministrativeAreaRequest.kt
@@ -1,10 +1,16 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.AdministrativeAreaType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Administrative Area Request", description = "New areas such as country regions or counties")
 data class AdministrativeAreaRequest (
+    @Schema(description = "Full name of the area")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand of the area")
     val shortName: String?,
+    @Schema(description = "FIPS code if applicable")
     val fipsCode: String?,
+    @Schema(description = "Type of specified area")
     val type: AdministrativeAreaType = AdministrativeAreaType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BankAccountRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BankAccountRequest.kt
@@ -1,12 +1,20 @@
 package com.catenax.gpdm.dto.request
 
 import com.neovisionaries.i18n.CurrencyCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Bank Account Request", description = "Bank account record of a business partner")
 data class BankAccountRequest(
+    @Schema(description = "Trust scores for the account", defaultValue = "[]")
     val trustScores: Collection<Float> = emptyList(),
+    @Schema(description = "Used currency in the account", defaultValue = "UNDEFINED")
     val currency: CurrencyCode = CurrencyCode.UNDEFINED,
+    @Schema(description = "ID used to identify this account internationally")
     val internationalBankAccountIdentifier: String,
+    @Schema(description = "ID used to identify the account's bank internationally")
     val internationalBankIdentifier: String,
+    @Schema(description = "ID used to identify the account domestically")
     val nationalBankAccountIdentifier: String,
+    @Schema(description = "ID used to identify the account's bank domestically")
     val nationalBankIdentifier: String,
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerRequest.kt
@@ -1,7 +1,6 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.BusinessPartnerType
-import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.NotEmpty

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerRequest.kt
@@ -1,14 +1,28 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.BusinessPartnerType
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotEmpty
 
+@Schema(name = "Business Partner Request", description = "New business partner record")
 data class BusinessPartnerRequest (
+    @ArraySchema(arraySchema = Schema(description = "Additional identifiers (except BPN)", required = false))
     val identifiers: Collection<IdentifierRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Names the partner goes by"), minItems = 1)
+    @field:NotEmpty
     val names: Collection<NameRequest>,
+    @Schema(description = "Technical key of the legal form")
     val legalForm: String?,
+    @Schema(description = "Current business status")
     val status: BusinessStatusRequest?,
+    @ArraySchema(arraySchema = Schema(description = "Addresses the partner is located at", required = false))
     val addresses: Collection<AddressRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "Profile classifications",  required = false))
     val profileClassifications: Collection<ClassificationRequest> = emptyList(),
+    @ArraySchema(arraySchema = Schema(description = "The type of partner",  required = false, defaultValue = "UNKNOWN"))
     val types: Collection<BusinessPartnerType> = listOf(BusinessPartnerType.UNKNOWN),
+    @ArraySchema(arraySchema = Schema(description = "Bank accounts of this partner",  required = false))
     val bankAccounts: Collection<BankAccountRequest> = emptyList()
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerSearchRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerSearchRequest.kt
@@ -1,12 +1,21 @@
 package com.catenax.gpdm.dto.request
 
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springdoc.api.annotations.ParameterObject
 import org.springframework.boot.context.properties.ConstructorBinding
 
+@Schema(name = "Business Partner Search Request", description = "Searching request for business partners by keywords in properties")
 data class BusinessPartnerSearchRequest @ConstructorBinding constructor(
+    @Parameter(description = "Which business partner name")
     val name: String?,
+    @Parameter(description = "Which legal form name")
     val legalForm: String?,
+    @Parameter(description = "Which business status designation")
     val status: String?,
+    @ParameterObject
     var address: AddressSearchRequest?,
+    @Parameter(description = "Which business classification")
     val classification: String?,
 )
 

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerSearchRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessPartnerSearchRequest.kt
@@ -1,21 +1,12 @@
 package com.catenax.gpdm.dto.request
 
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
-import org.springdoc.api.annotations.ParameterObject
 import org.springframework.boot.context.properties.ConstructorBinding
 
-@Schema(name = "Business Partner Search Request", description = "Searching request for business partners by keywords in properties")
 data class BusinessPartnerSearchRequest @ConstructorBinding constructor(
-    @Parameter(description = "Which business partner name")
     val name: String?,
-    @Parameter(description = "Which legal form name")
     val legalForm: String?,
-    @Parameter(description = "Which business status designation")
     val status: String?,
-    @ParameterObject
     var address: AddressSearchRequest?,
-    @Parameter(description = "Which business classification")
     val classification: String?,
 )
 

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessStatusRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/BusinessStatusRequest.kt
@@ -1,11 +1,17 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.BusinessStatusType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
+@Schema(name = "Business Status Request", description = "New status record for a business partner")
 data class BusinessStatusRequest (
+    @Schema(description = "Exact, official denotation of the status")
     val officialDenotation: String,
+    @Schema(description = "Since when the status is/was valid")
     val validFrom: LocalDateTime,
+    @Schema(description = "Until the status was valid, if applicable")
     val validUntil: LocalDateTime?,
+    @Schema(description = "The type of this specified status")
     val type: BusinessStatusType
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/ClassificationRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/ClassificationRequest.kt
@@ -1,9 +1,14 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.ClassificationType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Classification Request", description = "New classification record for a business partner")
 data class ClassificationRequest (
+        @Schema(description = "Name of the classification")
         val value: String,
+        @Schema(description = "Identifying code of the classification, if applicable")
         val code: String?,
+        @Schema(description = "Type of specified classification")
         val type: ClassificationType?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/IdentifierRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/IdentifierRequest.kt
@@ -1,8 +1,15 @@
 package com.catenax.gpdm.dto.request
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Identifier Request", description = "New identifier record for a business partner")
 data class IdentifierRequest (
+    @Schema(description = "Value of the identifier")
     val value: String,
+    @Schema(description = "Technical key of the type to which this identifier belongs to")
     val type: String,
+    @Schema(description = "Technical key of the body which issued this identifier")
     val issuingBody: String?,
+    @Schema(description = "Technical key of the status this identifier has")
     val status: String?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/LegalFormRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/LegalFormRequest.kt
@@ -2,12 +2,20 @@ package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.dto.response.type.TypeNameUrlDto
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Legal Form Request", description = "New legal form record to be referenced by business partners")
 data class LegalFormRequest(
+    @Schema(description = "Unique key to be used for reference")
     val technicalKey: String,
+    @Schema(description = "Full name of the legal form")
     val name: String,
+    @Schema(description = "Link for further information on the legal form")
     val url: String?,
+    @Schema(description = "Abbreviation of the legal form name")
     val mainAbbreviation: String?,
+    @Schema(description = "Language in which the legal form is specified", defaultValue = "undefined")
     val language: LanguageCode = LanguageCode.undefined,
+    @Schema(description = "Categories in which this legal form falls under", defaultValue = "[]")
     val category: Collection<TypeNameUrlDto> = emptyList()
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/LocalityRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/LocalityRequest.kt
@@ -1,9 +1,14 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.LocalityType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Locality Request", description = "New locality record for an address such as city, block or district")
 data class LocalityRequest (
+    @Schema(description = "Full name of the locality")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand of the locality's name, if applicable")
     val shortName: String?,
+    @Schema(description = "Type of specified locality", defaultValue = "OTHER")
     val type: LocalityType = LocalityType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/NameRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/NameRequest.kt
@@ -2,10 +2,16 @@ package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.NameType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Name Request", description = "New name record for a business partner")
 data class NameRequest (
+        @Schema(description = "Full name")
         val value: String,
+        @Schema(description = "Abbreviated name or shorthand")
         val shortName: String?,
+        @Schema(description = "Type of specified name", defaultValue = "OTHER")
         val type: NameType = NameType.OTHER,
+        @Schema(description = "Language in which the name is specified", defaultValue = "undefined")
         val language: LanguageCode = LanguageCode.undefined
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/PaginationRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/PaginationRequest.kt
@@ -1,13 +1,22 @@
 package com.catenax.gpdm.dto.request
 
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 import javax.validation.constraints.Positive
 import javax.validation.constraints.PositiveOrZero
 
+@Schema(name = "Pagination Request", description = "Defines pagination information for requesting collection results")
 data class PaginationRequest (
-    @PositiveOrZero
+    @field:Parameter(
+        description = "Number of page to get results from", schema =
+        Schema(defaultValue = "0"))
+    @field:PositiveOrZero
     val page: Int=0,
-    @Positive
-    @Max(100)
+    @field:Parameter(description = "Size of each page", schema =
+    Schema(defaultValue = "10"))
+    @field:Min(0)
+    @field:Max(100)
     val size: Int=10
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/PaginationRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/PaginationRequest.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
-import javax.validation.constraints.Positive
 import javax.validation.constraints.PositiveOrZero
 
 @Schema(name = "Pagination Request", description = "Defines pagination information for requesting collection results")

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/PostCodeRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/PostCodeRequest.kt
@@ -1,8 +1,12 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.PostCodeType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Postcode Request", description = "New postcode record for an address")
 data class PostCodeRequest (
+    @Schema(description = "Full postcode denotation")
     val value: String,
+    @Schema(description = "Type of specified postcode", defaultValue = "OTHER")
     val type: PostCodeType = PostCodeType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/PostalDeliveryPointRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/PostalDeliveryPointRequest.kt
@@ -1,10 +1,16 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.PostalDeliveryPointType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Postal Delivery Point Request", description = "New postal delivery point record for an address")
 data class PostalDeliveryPointRequest (
+    @Schema(description = "Full name of the delivery point")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand, if applicable")
     val shortName: String?,
+    @Schema(description = "Number/code of the delivery point, if applicable")
     val number: String?,
+    @Schema(description = "Type of the specified delivery point", defaultValue = "OTHER")
     val type: PostalDeliveryPointType = PostalDeliveryPointType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/PremiseRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/PremiseRequest.kt
@@ -1,10 +1,16 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.PremiseType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Premise Request", description = "New premise record for an address such as building, room or floor")
 data class PremiseRequest (
+    @Schema(description = "Full denotation of the premise")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand, if applicable")
     val shortName: String?,
+    @Schema(description = "Premise number, if applicable")
     val number: String?,
+    @Schema(description = "Type of specified premise", defaultValue = "OTHER")
     val type: PremiseType = PremiseType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/request/ThoroughfareRequest.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/request/ThoroughfareRequest.kt
@@ -1,12 +1,20 @@
 package com.catenax.gpdm.dto.request
 
 import com.catenax.gpdm.entity.ThoroughfareType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Thoroughfare Request", description = "New thoroughfare record for an address such as street, square or industrial zone")
 data class ThoroughfareRequest (
+        @Schema(description = "Full denotation of the thoroughfare")
         val value: String,
+        @Schema(description = "Full name of the thoroughfare")
         val name: String?,
+        @Schema(description = "Abbreviation or shorthand, if applicable")
         val shortName: String?,
+        @Schema(description = "Thoroughfare number, if applicable")
         val number: String?,
+        @Schema(description = "Direction information on the thoroughfare, if applicable")
         val direction: String?,
+        @Schema(description = "Type of specified thoroughfare", defaultValue = "OTHER")
         var type: ThoroughfareType = ThoroughfareType.OTHER
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/AddressResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/AddressResponse.kt
@@ -5,20 +5,35 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.AddressType
 import com.neovisionaries.i18n.CountryCode
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Address Response", description = "Localized address record of a business partner")
 data class AddressResponse (
     val uuid: UUID,
+    @Schema(description = "Language and character set the address is written in")
     val version: AddressVersionResponse,
+    @Schema(description = "Entity which is in care of this address")
     val careOf: String?,
+    @Schema(description = "Contexts of this address")
     val contexts: Collection<String>,
+    @Schema(description = "Address country")
     val country: TypeKeyNameDto<CountryCode>,
+    @ArraySchema(arraySchema = Schema(description = "Areas such as country region and county"))
     val administrativeAreas: Collection<AdministrativeAreaResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Postcodes assigned to this address"))
     val postCodes: Collection<PostCodeResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Localities such as city, block and quarter"))
     val localities: Collection<LocalityResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Thoroughfares such as street, zone and square"))
     val thoroughfares: Collection<ThoroughfareResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Premises such as building, level and room"))
     val premises: Collection<PremiseResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Delivery points for post"))
     val postalDeliveryPoints: Collection<PostalDeliveryPointResponse>,
+    @Schema(description = "Geographic coordinates to find this location")
     val geographicCoordinates: GeoCoordinateDto?,
+    @ArraySchema(arraySchema = Schema(description = "Types of this address"))
     val types: Collection<TypeKeyNameUrlDto<AddressType>>
     )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/AddressVersionResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/AddressVersionResponse.kt
@@ -3,8 +3,12 @@ package com.catenax.gpdm.dto.response
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.entity.CharacterSet
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Address Version Response", description = "Localization record of an address")
 data class AddressVersionResponse (
+    @Schema(description = "Character set in which the address is written")
     val characterSet: TypeKeyNameDto<CharacterSet>,
+    @Schema(description = "Language in which the address is written")
     val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/AdministrativeAreaResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/AdministrativeAreaResponse.kt
@@ -4,13 +4,21 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.AdministrativeAreaType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Administrative Area Response", description = "Area of an address such as country region or county")
 data class AdministrativeAreaResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Full name of the area")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand of the area")
     val shortName: String?,
+    @Schema(description = "FIPS code if applicable")
     val fipsCode: String?,
+    @Schema(description = "Type of specified area")
     val type: TypeKeyNameUrlDto<AdministrativeAreaType>,
+    @Schema(description = "Language the area is specified in")
     val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/BankAccountResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/BankAccountResponse.kt
@@ -2,14 +2,23 @@ package com.catenax.gpdm.dto.response
 
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.neovisionaries.i18n.CurrencyCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Bank Account Response", description = "Bank account record for a business partner")
 data class BankAccountResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Trust scores for the account", defaultValue = "[]")
     val trustScores: Collection<Float>,
+    @Schema(description = "Used currency in the account", defaultValue = "UNDEFINED")
     val currency: TypeKeyNameDto<CurrencyCode>,
+    @Schema(description = "ID used to identify this account internationally")
     val internationalBankAccountIdentifier: String,
+    @Schema(description = "ID used to identify the account's bank internationally")
     val internationalBankIdentifier: String,
+    @Schema(description = "ID used to identify the account domestically")
     val nationalBankAccountIdentifier: String,
-    val nationalBankIdentifier: String,
-        )
+    @Schema(description = "ID used to identify the account's bank domestically")
+    val nationalBankIdentifier: String
+    )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/BusinessPartnerResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/BusinessPartnerResponse.kt
@@ -4,17 +4,31 @@ package com.catenax.gpdm.dto.response
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.BusinessPartnerType
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Business Partner Response", description = "Business partner record")
 data class BusinessPartnerResponse (
+    @Schema(description = "Business Partner Number, main identifier value for business partners")
     val bpn: String,
+    @ArraySchema(arraySchema = Schema(description = "All identifiers of the business partner, including BPN information"))
     val identifiers: Collection<IdentifierResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Names the partner goes by"))
     val names: Collection<NameResponse>,
+    @Schema(description = "Legal form of the business partner")
     val legalForm: LegalFormResponse?,
+    @Schema(description = "Current business status")
     val status: BusinessStatusResponse?,
+    @ArraySchema(arraySchema = Schema(description = "Addresses the partner is located at"))
     val addresses: Collection<AddressResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Profile classifications"))
     val profileClassifications:  Collection<ClassificationResponse>,
+    @ArraySchema(arraySchema = Schema(description = "The partner types"))
     val types: Collection<TypeKeyNameUrlDto<BusinessPartnerType>>,
+    @ArraySchema(arraySchema = Schema(description = "Bank accounts of this partner"))
     val bankAccounts: Collection<BankAccountResponse>,
+    @ArraySchema(arraySchema = Schema(description = "Roles the partner takes in the Catena network"))
     val roles: Collection<TypeKeyNameDto<String>>,
+    @ArraySchema(arraySchema = Schema(description = "Relations to other business partners"))
     val relations: Collection<RelationResponse>
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/BusinessStatusResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/BusinessStatusResponse.kt
@@ -2,13 +2,20 @@ package com.catenax.gpdm.dto.response
 
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.BusinessStatusType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.*
 
+@Schema(name = "Business Status Response", description = "Status of a business partner")
 data class BusinessStatusResponse (
+        @Schema(description = "Unique identifier for reference purposes")
         val uuid: UUID,
+        @Schema(description = "Exact, official denotation of the status")
         val officialDenotation: String,
+        @Schema(description = "Since when the status is/was valid")
         val validFrom: LocalDateTime,
+        @Schema(description = "Until the status was valid, if applicable")
         val validUntil: LocalDateTime?,
+        @Schema(description = "The type of this status")
         val type: TypeKeyNameUrlDto<BusinessStatusType>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/ClassificationResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/ClassificationResponse.kt
@@ -1,8 +1,10 @@
 package com.catenax.gpdm.dto.response
 
 import com.catenax.gpdm.dto.response.type.TypeNameUrlDto
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Classification Response", description = "Classification record of a business partner")
 data class ClassificationResponse (
         val uuid: UUID,
         val value: String,

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/IdentifierResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/IdentifierResponse.kt
@@ -2,12 +2,19 @@ package com.catenax.gpdm.dto.response
 
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Identifier Response", description = "Identifier record of a business partner")
 data class IdentifierResponse (
+        @Schema(description = "Unique identifier for reference purposes")
         val uuid: UUID,
+        @Schema(description = "Value of the identifier")
         val value: String,
+        @Schema(description = "Type of the identifier")
         val type: TypeKeyNameUrlDto<String>,
+        @Schema(description = "Body which issued the identifier")
         val issuingBody:  TypeKeyNameUrlDto<String>?,
+        @Schema(description = "Status of the identifier")
         val status: TypeKeyNameDto<String>?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/LegalFormResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/LegalFormResponse.kt
@@ -3,12 +3,20 @@ package com.catenax.gpdm.dto.response
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeNameUrlDto
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(name = "Legal Form Response", description = "Legal form a business partner can have")
 data class LegalFormResponse (
+    @Schema(description = "Unique key to be used for reference")
     val technicalKey: String,
+    @Schema(description = "Full name of the legal form")
     val name: String,
+    @Schema(description = "Link for further information on the legal form")
     val url: String?,
+    @Schema(description = "Abbreviation of the legal form name")
     val mainAbbreviation: String?,
+    @Schema(description = "Language in which the legal form is specified")
     val language: TypeKeyNameDto<LanguageCode>,
+    @Schema(description = "Categories in which this legal form falls under")
     val categories: Collection<TypeNameUrlDto>
     )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/LocalityResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/LocalityResponse.kt
@@ -4,12 +4,19 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.LocalityType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Locality Response", description = "Locality record of an address such as city, block or district")
 data class LocalityResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Full name of the locality")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand of the locality's name")
     val shortName: String?,
+    @Schema(description = "Type of locality")
     val type: TypeKeyNameUrlDto<LocalityType>,
+    @Schema(description = "Language the locality is specified in")
     val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/NameResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/NameResponse.kt
@@ -4,12 +4,19 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.NameType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Name Response", description = "Name record of a business partner")
 data class NameResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Full name")
     val value: String,
+    @Schema(description = "Abbreviated name or shorthand")
     val shortName: String?,
+    @Schema(description = "Type of name")
     val type: TypeKeyNameUrlDto<NameType>,
+    @Schema(description = "Language in which the name is specified")
     val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/PageResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/PageResponse.kt
@@ -1,9 +1,17 @@
 package com.catenax.gpdm.dto.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Paginated collection of results")
 data class PageResponse<T> (
+    @Schema(description = "Total number of all results in all pages")
     val totalElements: Long,
+    @Schema(description = "Total number pages")
     val totalPages: Int,
+    @Schema(description = "Current page number")
     val page: Int,
+    @Schema(description = "Number of results in the page")
     val contentSize: Int,
+    @Schema(description = "Collection of results in the page")
     val content: Collection<T>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/PostCodeResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/PostCodeResponse.kt
@@ -2,10 +2,15 @@ package com.catenax.gpdm.dto.response
 
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.PostCodeType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Postcode Response", description = "Postcode record of an address")
 data class PostCodeResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Full postcode denotation")
     val value: String,
+    @Schema(description = "Type of specified postcode")
     val type: TypeKeyNameUrlDto<PostCodeType>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/PostalDeliveryPointResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/PostalDeliveryPointResponse.kt
@@ -4,13 +4,21 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.PostalDeliveryPointType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Postal Delivery Point Response", description = "Postal delivery point record of an address")
 data class PostalDeliveryPointResponse (
+        @Schema(description = "Unique identifier for reference purposes")
         val uuid: UUID,
+        @Schema(description = "Full denotation of the delivery point")
         val value: String,
+        @Schema(description = "Abbreviation or shorthand of the locality's name")
         val shortName: String?,
+        @Schema(description = "Number/code of the delivery point")
         val number: String?,
+        @Schema(description = "Type of the specified delivery point")
         val type: TypeKeyNameUrlDto<PostalDeliveryPointType>,
+        @Schema(description = "Language the delivery point is specified in")
         val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/PremiseResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/PremiseResponse.kt
@@ -4,13 +4,21 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.PremiseType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(name = "Premise Response", description = "Premise record of an address such as building, room or floor")
 data class PremiseResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Full denotation of the premise")
     val value: String,
+    @Schema(description = "Abbreviation or shorthand")
     val shortName: String?,
+    @Schema(description = "Premise number")
     val number: String?,
+    @Schema(description = "Type of premise")
     val type: TypeKeyNameUrlDto<PremiseType>,
+    @Schema(description = "Language the premise is specified in")
     val language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/RelationResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/RelationResponse.kt
@@ -3,15 +3,24 @@ package com.catenax.gpdm.dto.response
 import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.entity.RelationClass
 import com.catenax.gpdm.entity.RelationType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.*
 
+@Schema(name = "Relation Response", description = "Directed relation between two business partners")
 data class RelationResponse (
+    @Schema(description = "Unique identifier for reference purposes")
     val uuid: UUID,
+    @Schema(description = "Class of relation like Catena, LEI or DNB relation")
     val relationClass: TypeKeyNameDto<RelationClass>,
+    @Schema(description = "Type of relation like predecessor or ownership relation")
     val type: TypeKeyNameDto<RelationType>,
+    @Schema(description = "BPN of partner which is the source of the relation")
     val startNode: String,
+    @Schema(description = "BPN of partner which is the target of the relation")
     val endNode: String,
+    @Schema(description = "Time when the relation started")
     val startedAt: LocalDateTime?,
+    @Schema(description = "Time when the relation ended")
     val endedAt: LocalDateTime?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/ThoroughfareResponse.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/ThoroughfareResponse.kt
@@ -4,16 +4,25 @@ import com.catenax.gpdm.dto.response.type.TypeKeyNameDto
 import com.catenax.gpdm.dto.response.type.TypeKeyNameUrlDto
 import com.catenax.gpdm.entity.ThoroughfareType
 import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
-
+@Schema(name = "Thoroughfare Response", description = "Thoroughfare record of an address such as street, square or industrial zone")
 class ThoroughfareResponse (
+        @Schema(description = "Unique identifier for reference purposes")
         val uuid: UUID,
+        @Schema(description = "Full denotation of the thoroughfare")
         val value: String,
+        @Schema(description = "Full name of the thoroughfare")
         val name: String?,
+        @Schema(description = "Abbreviation or shorthand")
         val shortName: String?,
+        @Schema(description = "Thoroughfare number")
         val number: String?,
+        @Schema(description = "Direction information on the thoroughfare")
         val direction: String?,
+        @Schema(description = "Type of thoroughfare", defaultValue = "OTHER")
         var type: TypeKeyNameUrlDto<ThoroughfareType>,
+        @Schema(description = "Language the thoroughfare is specified in")
         var language: TypeKeyNameDto<LanguageCode>
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeKeyNameDto.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeKeyNameDto.kt
@@ -1,6 +1,11 @@
 package com.catenax.gpdm.dto.response.type
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Named type uniquely identified by its technical key")
 data class TypeKeyNameDto <T>(
+    @Schema(description = "Unique key of this type for reference")
     val technicalKey: T,
+    @Schema(description = "Name or denotation of this type")
     val name: String,
 )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeKeyNameUrlDto.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeKeyNameUrlDto.kt
@@ -1,7 +1,12 @@
 package com.catenax.gpdm.dto.response.type
 
-data class TypeKeyNameUrlDto <T> (
-        val technicalKey: T,
-        val name: String,
-        val url: String?
+import io.swagger.v3.oas.annotations.media.Schema
+
+open class TypeKeyNameUrlDto <T> (
+        @Schema(description = "Unique key of this type for reference")
+        open val technicalKey: T,
+        @Schema(description = "Name or denotation of this type")
+        open val name: String,
+        @Schema(description = "URL link leading to page with further information on the type")
+        open val url: String?
         )

--- a/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeNameUrlDto.kt
+++ b/src/main/kotlin/com/catenax/gpdm/dto/response/type/TypeNameUrlDto.kt
@@ -1,6 +1,11 @@
 package com.catenax.gpdm.dto.response.type
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Named Type With Link", description = "General type with name and URL link for further information")
 data class TypeNameUrlDto (
+    @Schema(description = "Name of the type")
     val name: String,
+    @Schema(description = "URL link leading to page with further information on the type")
     val url: String?
         )

--- a/src/main/kotlin/com/catenax/gpdm/exception/BpdmAlreadyExists.kt
+++ b/src/main/kotlin/com/catenax/gpdm/exception/BpdmAlreadyExists.kt
@@ -3,7 +3,7 @@ package com.catenax.gpdm.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
-@ResponseStatus(HttpStatus.BAD_REQUEST)
+@ResponseStatus(HttpStatus.CONFLICT)
 class BpdmAlreadyExists (
     objectType: String,
     identifier: String

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,7 @@ keycloak.enabled=false
 
 #Springdoc swagger configuration
 springdoc.swagger-ui.path=/api/swagger-ui
+springdoc.swagger-ui.show-common-extensions=true
 
 #Default Elasticsearch configuration
 bpdm.elastic.enabled=false


### PR DESCRIPTION
SpringDoc OpenAPI can't easily have custom schema names for generic types. In order to provide custom names the effort currently doesn't justify the benefit. That's why you will run across some strange names for some schemas there.